### PR TITLE
add: support for multi-zone scatter tickets

### DIFF
--- a/paikkala/models/zones.py
+++ b/paikkala/models/zones.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Set
 
 from django.db import models
@@ -8,20 +9,12 @@ if TYPE_CHECKING:
     from paikkala.models.rows import Row
 
 
-# TODO(3.7): dataclass-ify
+@dataclass
 class RowReservationStatus:
-    def __init__(
-        self,
-        *,
-        capacity: int,
-        reserved: int,
-        remaining: int,
-        blocked_set: Set[int],
-    ) -> None:
-        self.capacity = capacity
-        self.reserved = reserved
-        self.remaining = remaining
-        self.blocked_set = blocked_set
+    capacity: int
+    reserved: int
+    remaining: int
+    blocked_set: Set[int]
 
 
 class ZoneReservationStatus(dict):

--- a/paikkala/tests/conftest.py
+++ b/paikkala/tests/conftest.py
@@ -8,6 +8,7 @@ from django.utils.timezone import now
 from paikkala.models import Program, Room, Row, Zone
 from paikkala.tests.demo_data import (
     create_jussi_program,
+    create_scatter_program,
     create_workshop_program,
     create_workshop_room,
     create_workshop_row,
@@ -24,6 +25,11 @@ def sibeliustalo_zones():
 @pytest.fixture
 def jussi_program(sibeliustalo_zones):
     return create_jussi_program(sibeliustalo_zones)
+
+
+@pytest.fixture
+def scatter_program(sibeliustalo_zones):
+    return create_scatter_program(sibeliustalo_zones)
 
 
 @pytest.fixture

--- a/paikkala/tests/demo_data.py
+++ b/paikkala/tests/demo_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from datetime import timedelta
 
@@ -37,6 +39,40 @@ def create_jussi_program(zones, room=None):
         max_tickets_per_batch=1000,
     )
     program.rows.set(Row.objects.filter(zone__in=zones))
+    return program
+
+
+def create_scatter_program(zones: list[Zone], room=None):
+    if not room:
+        room = zones[0].room
+    program = Program.objects.create(
+        room=room,
+        name='Hyvin suosittu ohjelmanumero',
+        reservation_start=now() - timedelta(hours=1),
+        reservation_end=now() + timedelta(hours=1),
+        max_tickets=1_000_000,
+        max_tickets_per_batch=1_000_000,
+    )
+    program.rows.set(Row.objects.filter(zone__in=zones))
+
+    for zone in zones:
+        row: Row
+        for row in zone.rows.all():
+            # Leave one seat per row
+            _ = list(row.reserve(
+                program=program,
+                count=row.capacity - 1,
+                user=None,
+                name='Señor Developer',
+                email='test@localhost',
+                phone=None,
+                attempt_sequential=False,
+                excluded_numbers=None,
+            ))
+
+        status = zone.get_reservation_status(program)
+        assert status.total_remaining == zone.rows.count()
+
     return program
 
 

--- a/paikkala/tests/test_paikkala.py
+++ b/paikkala/tests/test_paikkala.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from django.contrib.auth.models import AnonymousUser
 
@@ -23,7 +25,7 @@ def test_is_reservable(jussi_program):
 
 
 @pytest.mark.django_db
-def test_reserve_non_scatter(jussi_program):
+def test_reserve_non_scatter_single_zone(jussi_program):
     zone = jussi_program.zones.get(name='Aitio 1 (vasen)')
     assert zone.capacity == 9
     with pytest.raises(NoCapacity):
@@ -35,6 +37,18 @@ def test_reserve_non_scatter(jussi_program):
 
 
 @pytest.mark.django_db
+def test_reserve_non_scatter_multi_zone(jussi_program):
+    jussi_program.max_tickets = 1_000
+    max_zone_capacity = max(z.get_reservation_status(jussi_program).total_capacity for z in jussi_program.zones)
+    n_to_reserve = 21
+    with pytest.raises(NoCapacity, match=r'from any single zone \(no scatter\)'):
+        list(jussi_program.reserve(zone=None, count=max_zone_capacity + 1, allow_scatter=False))
+    tickets = list(jussi_program.reserve(zone=None, count=n_to_reserve, allow_scatter=False))
+    assert len(tickets) == n_to_reserve
+    assert all(t.zone == tickets[0].zone for t in tickets)
+
+
+@pytest.mark.django_db
 def test_reserve_limit(jussi_program):
     zone = jussi_program.zones.get(name='Permanto')
     with pytest.raises(MaxTicketsReached):
@@ -42,19 +56,43 @@ def test_reserve_limit(jussi_program):
 
 
 @pytest.mark.django_db
-def test_reserve_scatter(jussi_program):
-    jussi_program.max_tickets = 1000
+def test_reserve_scatter_single_zone(jussi_program):
+    jussi_program.max_tickets = 1_000
     zone = jussi_program.zones.get(name='Permanto')
     assert zone.capacity == 650
     n_to_reserve = 494
     with pytest.raises(NoCapacity):
-        list(jussi_program.reserve(zone=zone, count=n_to_reserve))
+        list(jussi_program.reserve(zone=zone, count=zone.capacity + 1, allow_scatter=True))
     tickets = list(jussi_program.reserve(zone=zone, count=n_to_reserve, allow_scatter=True))
     assert len(tickets) == n_to_reserve
     rstat = zone.get_reservation_status(program=jussi_program)
     assert sum(r.reserved for r in rstat.values()) == n_to_reserve  # Reservations line up
     assert sum(r.remaining for r in rstat.values()) == zone.capacity - n_to_reserve  # Free slots line up
     assert any(r.reserved and r.capacity for r in rstat.values())  # Check that we have semi-reserved rows
+
+
+@pytest.mark.django_db
+def test_reserve_scatter_multi_zone(scatter_program):
+    scatter_program.max_tickets = 1_000_000
+    assert scatter_program.is_reservable()
+
+    rstat_before = {z: z.get_reservation_status(scatter_program) for z in scatter_program.zones}
+    total_reserved_before = sum(rs.total_reserved for rs in rstat_before.values())
+
+    n_to_reserve = sum(z.rows.count() for z in scatter_program.zones)
+    tickets = list(scatter_program.reserve(zone=None, count=n_to_reserve, allow_scatter=True))
+
+    rstat_after = {z: z.get_reservation_status(scatter_program) for z in scatter_program.zones}
+    total_reserved_after = sum(rs.total_reserved for rs in rstat_after.values())
+
+    assert len(tickets) == n_to_reserve
+    assert total_reserved_after == total_reserved_before + n_to_reserve
+
+
+@pytest.mark.django_db
+def test_reserve_scatter_multi_zone_fail(scatter_program):
+    with pytest.raises(NoCapacity):
+        list(scatter_program.reserve(zone=None, count=1_000, allow_scatter=True))
 
 
 @pytest.mark.django_db

--- a/paikkala/tests/test_views.py
+++ b/paikkala/tests/test_views.py
@@ -15,6 +15,7 @@ def test_reserve(jussi_program, user_client):
             {
                 'zone': jussi_program.zones[0].pk,
                 'count': 5,
+                'allow_scatter': 0,
             },
         ).status_code
         == 302


### PR DESCRIPTION
Scatter works now differently based on if the requested zone is `None` or not:

* Single zone, no scatter: only a contiguous chunk of tickets from a single row in the specified zone is accepted
* Single zone, scatter allowed: the requested amount of tickets scattered across any number of chunks in a single zone is accepted
* Any zone, no scatter: a contiguous chunk of tickets from a single row in any zone is accepted
* Any zone, scatter allowed: the requested amount of tickets scattered across any number of chunks in any number of zones is accepted